### PR TITLE
Enable loading weights from checkpoints

### DIFF
--- a/cdm/models/__init__.py
+++ b/cdm/models/__init__.py
@@ -1,4 +1,5 @@
 from .schnet_charge import schnet_charge
 from .gemnet_charge import GemNetT_charge
 from .painn_charge import PaiNN_Charge
+from .scn_charge import SCN_Charge
 from .chargemodel import ChargeModel

--- a/cdm/models/chargemodel.py
+++ b/cdm/models/chargemodel.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 import warnings
 
 from torch_geometric.data import Batch
-from torch_geometric.utils import remove_isolated_nodes
+from torch_geometric.utils import remove_isolated_nodes, sort_edge_index
 
 from ocpmodels.common.utils import conditional_grad
 from ocpmodels.common.registry import registry
@@ -115,6 +115,8 @@ class ChargeModel(torch.nn.Module):
     @conditional_grad(torch.enable_grad())        
     def forward_probe(self, data, atom_representations):
         data.atom_representations = atom_representations
+        data.edge_index = sort_edge_index(data.edge_index.flipud()).flipud()
+
         probe_representations = self.probe_message_model(data)
         probe_results = self.probe_output_function(probe_representations).flatten()
         probe_results = torch.nan_to_num(probe_results)

--- a/cdm/models/chargemodel.py
+++ b/cdm/models/chargemodel.py
@@ -1,3 +1,4 @@
+import os
 import torch
 from ase import Atoms
 from pymatgen.core.sites import PeriodicSite
@@ -9,10 +10,11 @@ import warnings
 from torch_geometric.data import Batch
 from torch_geometric.utils import remove_isolated_nodes, sort_edge_index
 
-from ocpmodels.common.utils import conditional_grad
-from ocpmodels.common.registry import registry
 from ocpmodels.datasets import data_list_collater
+from ocpmodels.common.registry import registry
+from ocpmodels.common.utils import conditional_grad
 from ocpmodels.common.utils import pyg2_data_transform
+from ocpmodels.common.utils import load_state_dict
 
 from cdm.utils.probe_graph import ProbeGraphAdder
 
@@ -21,77 +23,99 @@ from cdm.utils.probe_graph import ProbeGraphAdder
 class ChargeModel(torch.nn.Module):
     def __init__(
         self,
-        atom_model_config = {'name': 'schnet_charge'},
-        probe_model_config = {'name': 'schnet_charge'},
-        otf_pga_config = {'num_probes': 500,
-                          'cutoff': 4,
-                          'include_atomic_edges': False,
-                          'mode': 'random',
-                          'stride': 1,
-                          'implementation': 'RGPBC',
-                         },
-        atom_channels = 128,
-        probe_channels = 128,
+        atom_model_config,
+        probe_model_config,
+        otf_pga_config = {},
         include_atomic_edges = False,
         enforce_zero_for_disconnected_probes = False,
         enforce_charge_conservation = False,
+        freeze_atomic = False,
         name = 'charge_model',
     ):
         super().__init__()
+        
         self.regress_forces = False
         self.enforce_zero_for_disconnected_probes = enforce_zero_for_disconnected_probes
         self.enforce_charge_conservation = enforce_charge_conservation
-        probe_final_mlp = True
+        self.freeze_atomic = freeze_atomic
         
+        probe_final_mlp = True
+            
+        # Initialize atom message-passing model
+        if 'checkpoint' in atom_model_config:
+            cfg = torch.load(
+                atom_model_config['checkpoint'],
+                map_location=torch.device('cpu')
+            )['config']['model_attributes']
+        else:
+            cfg = atom_model_config
+
+        
+        self.atom_message_model = registry.get_model_class(atom_model_config['name'])(
+            **cfg,
+            atomic=True, 
+            probe=False,
+        )
+        
+        if 'checkpoint' in atom_model_config:
+            self.load_checkpoint(
+                checkpoint_path = atom_model_config['checkpoint'],
+                atomic = True,
+            )
+        
+        
+        # Initialize probe message-passing model
+        if 'checkpoint' in probe_model_config:
+            cfg = torch.load(
+                probe_model_config['checkpoint'],
+                map_location=torch.device('cpu')
+            )['config']['model_attributes']
+        else:
+            cfg = probe_model_config
+
+        
+        self.probe_message_model = registry.get_model_class(probe_model_config['name'])(
+            **cfg,
+            atomic=False, 
+            probe=True,
+        )
+        
+        if 'checkpoint' in probe_model_config:
+            self.load_checkpoint(
+                checkpoint_path = probe_model_config['checkpoint'],
+                probe = True,
+            )
+        
+        # Ensure match between atom and probe messaging models
+        if self.atom_message_model.hidden_channels != self.probe_message_model.hidden_channels:
+            self.reduce_atom_representations = True
+            self.atom_reduction = torch.nn.Sequential(
+                torch.nn.Linear(self.atom_message_model.hidden_channels,self.atom_message_model.hidden_channels),
+                torch.nn.Sigmoid(),
+                torch.nn.Linear(self.atom_message_model.hidden_channels, self.probe_message_model.hidden_channels))
+        else:
+            self.reduce_atom_representations = False
+            
+        assert self.atom_message_model.num_interactions >= self.probe_message_model.num_interactions
+        
+        # Compatibility for specific models
         if probe_model_config['name'] == 'scn_charge':
             probe_final_mlp = False
         
         if probe_final_mlp:
             self.probe_output_function = torch.nn.Sequential(
-                torch.nn.Linear(probe_channels, probe_channels),
+                torch.nn.Linear(self.probe_message_model.hidden_channels, self.probe_message_model.hidden_channels),
                 torch.nn.ELU(),
-                torch.nn.Linear(probe_channels, 1)
+                torch.nn.Linear(self.probe_message_model.hidden_channels, 1)
             )
-
-        
-        self.atom_message_model = registry.get_model_class(atom_model_config['name'])(
-            **atom_model_config,
-            atomic=True, 
-            probe=False,
-            hidden_channels = atom_channels,
-        )
-        
-        self.probe_message_model = registry.get_model_class(probe_model_config['name'])(
-            **probe_model_config,
-            atomic=False,
-            probe=True,
-            hidden_channels = probe_channels,
-        )
-        
+            
         if atom_model_config['name'] == 'gemnet_charge' or probe_model_config['name'] == 'gemnet_charge':
             self.include_atomic_edges = True
         else:
             self.include_atomic_edges = False
             
-        if atom_channels != probe_channels:
-            self.reduce_atom_representations = True
-            self.atom_reduction = torch.nn.Sequential(
-                torch.nn.Linear(atom_channels, atom_channels),
-                torch.nn.Sigmoid(),
-                torch.nn.Linear(atom_channels, probe_channels))
-        else:
-            self.reduce_atom_representations = False
             
-        assert self.atom_message_model.num_interactions >= self.probe_message_model.num_interactions
-            
-        self.otf_pga = ProbeGraphAdder(
-            num_probes = otf_pga_config['num_probes'],
-            cutoff = otf_pga_config['cutoff'],
-            include_atomic_edges = otf_pga_config['include_atomic_edges'],
-            mode = otf_pga_config['mode'],
-            stride = otf_pga_config['stride'],
-            implementation = otf_pga_config['implementation'],
-        )
+        self.otf_pga = ProbeGraphAdder(**otf_pga_config)
         
         
     @conditional_grad(torch.enable_grad())
@@ -110,7 +134,13 @@ class ChargeModel(torch.nn.Module):
     
     @conditional_grad(torch.enable_grad())
     def forward_atomic(self, data):
-        atom_representations = self.atom_message_model(data)
+        data.edge_index = sort_edge_index(data.edge_index.flipud()).flipud()
+        
+        if self.freeze_atomic:
+            with torch.no_grad():
+                atom_representations = self.atom_message_model(data)
+        else:
+            atom_representations = self.atom_message_model(data)
         
         if self.reduce_atom_representations:
             atom_representations = [self.atom_reduction(rep).float() for rep in atom_representations]
@@ -119,7 +149,8 @@ class ChargeModel(torch.nn.Module):
             
     @conditional_grad(torch.enable_grad())        
     def forward_probe(self, data, atom_representations):
-        data.atom_representations = atom_representations[-self.probe_message_model.num_interactions]
+        data.atom_representations = atom_representations[-self.probe_message_model.num_interactions:]
+        
         data.edge_index = sort_edge_index(data.edge_index.flipud()).flipud()
         
         probe_results = self.probe_message_model(data)
@@ -147,3 +178,46 @@ class ChargeModel(torch.nn.Module):
     @property
     def num_params(self):
         return sum(p.numel() for p in self.parameters())
+    
+    
+    def load_checkpoint(
+        self,
+        checkpoint_path,
+        atomic=False,
+        probe=False
+    ):
+        if not os.path.isfile(checkpoint_path):
+            raise FileNotFoundError(
+                errno.ENOENT, "Checkpoint file not found", checkpoint_path
+            )
+
+        if atomic:
+            model = self.atom_message_model
+        if probe:
+            model = self.probe_message_model
+        
+        map_location = torch.device("cpu") if self.cpu else self.device
+        checkpoint = torch.load(checkpoint_path, map_location=map_location)
+
+        # Match the "module." count in the keys of model and checkpoint state_dict
+        # DataParallel model has 1 "module.",  DistributedDataParallel has 2 "module."
+        # Not using either of the above two would have no "module."
+
+        ckpt_key_count = next(iter(checkpoint["state_dict"])).count("module")
+        mod_key_count = next(iter(model.state_dict())).count("module")
+        key_count_diff = mod_key_count - ckpt_key_count
+
+        if key_count_diff > 0:
+            new_dict = {
+                key_count_diff * "module." + k: v
+                for k, v in checkpoint["state_dict"].items()
+            }
+        elif key_count_diff < 0:
+            new_dict = {
+                k[len("module.") * abs(key_count_diff) :]: v
+                for k, v in checkpoint["state_dict"].items()
+            }
+        else:
+            new_dict = checkpoint["state_dict"]
+            
+        load_state_dict(model, new_dict, strict=False)

--- a/cdm/models/painn_charge.py
+++ b/cdm/models/painn_charge.py
@@ -58,6 +58,7 @@ class PaiNN_Charge(PaiNN):
         )
         self.atomic = atomic
         self.probe = probe
+        self.num_interactions = num_interactions
         
     @conditional_grad(torch.enable_grad())
     def forward(self, data):

--- a/cdm/models/painn_charge.py
+++ b/cdm/models/painn_charge.py
@@ -3,8 +3,6 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-import pdb
-
 from ocpmodels.common.registry import registry
 import torch
 from ocpmodels.models.painn.painn import PaiNN

--- a/cdm/models/schnet_charge.py
+++ b/cdm/models/schnet_charge.py
@@ -17,39 +17,22 @@ from ocpmodels.common.utils import (
 class schnet_charge(SchNet):
     def __init__(
         self,
-        use_pbc=True,
-        regress_forces=False,
-        otf_graph=False,
-        
-        hidden_channels=128,
-        num_filters=128,
-        num_interactions=6,
-        num_gaussians=50,
-        cutoff=10.0,
-        readout="add",
-        
-        atomic=False,
-        probe=False,
         name='schnet_charge',
+        **kwargs,
     ):
 
+        self.atomic = kwargs['atomic']
+        self.probe = kwargs['probe']
+        kwargs.pop('atomic')
+        kwargs.pop('probe')
+                 
         super().__init__(
             num_atoms = 1,
             bond_feat_dim = 1,
             num_targets = 1,
-            use_pbc=True,
-            regress_forces=False,
-            otf_graph=False,
-            hidden_channels=hidden_channels,
-            num_filters=num_filters,
-            num_interactions=num_interactions,
-            num_gaussians=num_gaussians,
-            cutoff=cutoff,
-            readout=readout
+            otf_graph = False,
+            **kwargs,
         )
-        self.atomic = atomic
-        self.probe = probe
-        self.num_interactions = num_interactions
 
     @conditional_grad(torch.enable_grad())
     def forward(self, data):
@@ -90,7 +73,7 @@ class schnet_charge(SchNet):
             edge_attr = edge_attr.float()
             
             for interaction_number, interaction in enumerate(self.interactions):
-                h = h + interaction(h, edge_index, edge_weight, edge_attr)
                 h[atom_indices] = data.atom_representations[interaction_number]
+                h = h + interaction(h, edge_index, edge_weight, edge_attr)
 
             return h[probe_indices]

--- a/cdm/models/schnet_charge.py
+++ b/cdm/models/schnet_charge.py
@@ -13,8 +13,6 @@ from ocpmodels.common.utils import (
     radius_graph_pbc,
 )
 
-import pdb
-
 @registry.register_model("schnet_charge")
 class schnet_charge(SchNet):
     def __init__(

--- a/cdm/models/schnet_charge.py
+++ b/cdm/models/schnet_charge.py
@@ -49,6 +49,7 @@ class schnet_charge(SchNet):
         )
         self.atomic = atomic
         self.probe = probe
+        self.num_interactions = num_interactions
 
     @conditional_grad(torch.enable_grad())
     def forward(self, data):

--- a/cdm/models/scn_charge.py
+++ b/cdm/models/scn_charge.py
@@ -76,7 +76,7 @@ class SCN_Charge(SCN):
 
     def __init__(
         self,
-        max_num_neighbors=1000000,
+        max_num_neighbors=10000,
         cutoff=4.0,
         max_num_elements=90,
         num_interactions=8,
@@ -181,8 +181,6 @@ class SCN_Charge(SCN):
         ###############################################################
         # Initialize data structures
         ###############################################################
-
-        #pdb.set_trace()
         
         # Calculate which message block each edge should use. Based on edge distance rank.
         edge_rank = self._rank_edge_distances(

--- a/cdm/models/scn_charge.py
+++ b/cdm/models/scn_charge.py
@@ -131,6 +131,7 @@ class SCN_Charge(SCN):
         
         self.atomic = atomic
         self.probe = probe
+        self.num_interactions = num_interactions
 
         
 

--- a/cdm/models/scn_charge.py
+++ b/cdm/models/scn_charge.py
@@ -5,8 +5,6 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-import pdb
-
 import logging
 import time
 

--- a/cdm/models/scn_charge.py
+++ b/cdm/models/scn_charge.py
@@ -1,0 +1,302 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import pdb
+
+import logging
+import time
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch_geometric.nn import radius_graph
+
+from ocpmodels.models.scn.scn import SphericalChannelNetwork as SCN
+
+from ocpmodels.common.registry import registry
+from ocpmodels.common.utils import (
+    conditional_grad,
+    get_pbc_distances,
+    radius_graph_pbc,
+)
+from ocpmodels.models.base import BaseModel
+from ocpmodels.models.scn.sampling import CalcSpherePoints
+from ocpmodels.models.scn.smearing import (
+    GaussianSmearing,
+    LinearSigmoidSmearing,
+    SigmoidSmearing,
+    SiLUSmearing,
+)
+from ocpmodels.models.scn.spherical_harmonics import SphericalHarmonicsHelper
+
+try:
+    import e3nn
+    from e3nn import o3
+except ImportError:
+    pass
+
+
+@registry.register_model("scn_charge")
+class SCN_Charge(SCN):
+    """Spherical Channel Network
+    Paper: Spherical Channels for Modeling Atomic Interactions
+
+    Args:
+        use_pbc (bool):         Use periodic boundary conditions
+        regress_forces (bool):  Compute forces
+        otf_graph (bool):       Compute graph On The Fly (OTF)
+        max_num_neighbors (int): Maximum number of neighbors per atom
+        cutoff (float):         Maximum distance between nieghboring atoms in Angstroms
+        max_num_elements (int): Maximum atomic number
+
+        num_interactions (int): Number of layers in the GNN
+        lmax (int):             Maximum degree of the spherical harmonics (1 to 10)
+        mmax (int):             Maximum order of the spherical harmonics (0 or 1)
+        num_resolutions (int):  Number of resolutions used to compute messages, further away atoms has lower resolution (1 or 2)
+        sphere_channels (int):  Number of spherical channels
+        sphere_channels_reduce (int): Number of spherical channels used during message passing (downsample or upsample)
+        hidden_channels (int):  Number of hidden units in message passing
+        num_taps (int):         Number of taps or rotations used during message passing (1 or otherwise set automatically based on mmax)
+
+        use_grid (bool):        Use non-linear pointwise convolution during aggregation
+        num_bands (int):        Number of bands used during message aggregation for the 1x1 pointwise convolution (1 or 2)
+
+        num_sphere_samples (int): Number of samples used to approximate the integration of the sphere in the output blocks
+        num_basis_functions (int): Number of basis functions used for distance and atomic number blocks
+        distance_function ("gaussian", "sigmoid", "linearsigmoid", "silu"):  Basis function used for distances
+        basis_width_scalar (float): Width of distance basis function
+        distance_resolution (float): Distance between distance basis functions in Angstroms
+
+        show_timing_info (bool): Show timing and memory info
+    """
+
+    def __init__(
+        self,
+        max_num_neighbors=10000,
+        cutoff=4.0,
+        max_num_elements=90,
+        num_interactions=4,
+        lmax=3,
+        mmax=1,
+        num_resolutions=2,
+        sphere_channels=128,
+        sphere_channels_reduce=128,
+        hidden_channels=256,
+        num_taps=-1,
+        use_grid=True,
+        num_bands=1,
+        num_sphere_samples=128,
+        num_basis_functions=128,
+        distance_function="gaussian",
+        basis_width_scalar=1.0,
+        distance_resolution=0.02,
+        show_timing_info=True,
+        direct_forces=True,
+        name='scn_charge',
+        atomic=False,
+        probe=False,
+    ):
+        super().__init__(
+            num_atoms = 1,
+            bond_feat_dim = 1,
+            num_targets = 1,
+            use_pbc = True,
+            regress_forces = False,
+            otf_graph = False,
+            max_num_neighbors = max_num_neighbors,
+            cutoff = cutoff,
+            max_num_elements = max_num_elements,
+            num_interactions = num_interactions,
+            lmax = lmax,
+            mmax = mmax,
+            num_resolutions = num_resolutions,
+            sphere_channels = sphere_channels,  ##
+            sphere_channels_reduce = sphere_channels_reduce, ##
+            hidden_channels = hidden_channels, ##
+            num_taps = num_taps,
+            use_grid = use_grid,
+            num_bands = num_bands,
+            num_sphere_samples = num_sphere_samples,
+            num_basis_functions = num_basis_functions,
+            distance_function = distance_function,
+            basis_width_scalar = basis_width_scalar,
+            distance_resolution = distance_resolution,
+            show_timing_info = show_timing_info,
+            direct_forces = direct_forces,
+        )
+        
+        self.atomic = atomic
+        self.probe = probe
+
+        
+
+    @conditional_grad(torch.enable_grad())
+    def forward(self, data):
+        self.device = data.pos.device
+        self.num_atoms = len(data.batch)
+        self.batch_size = len(data.natoms)
+        # torch.autograd.set_detect_anomaly(True)
+
+        start_time = time.time()
+
+        outputs = self._forward_helper(
+            data,
+        )
+
+        if self.show_timing_info is True:
+            torch.cuda.synchronize()
+            print(
+                "{} Time: {}\tMemory: {}\t{}".format(
+                    self.counter,
+                    time.time() - start_time,
+                    len(data.pos),
+                    torch.cuda.max_memory_allocated() / 1000000,
+                )
+            )
+
+        self.counter = self.counter + 1
+
+        return outputs
+
+    # restructure forward helper for conditional grad
+    def _forward_helper(self, data):
+        atomic_numbers = data.atomic_numbers.long()
+        num_atoms = len(atomic_numbers)
+        pos = data.pos
+
+        (
+            edge_index,
+            edge_distance,
+            edge_distance_vec,
+            cell_offsets,
+            _,  # cell offset distances
+            neighbors,
+        ) = self.generate_graph(data)
+
+        ###############################################################
+        # Initialize data structures
+        ###############################################################
+
+        # Calculate which message block each edge should use. Based on edge distance rank.
+        edge_rank = self._rank_edge_distances(
+            edge_distance, edge_index, self.max_num_neighbors
+        )
+
+        # Reorder edges so that they are grouped by distance rank (lowest to highest)
+        last_cutoff = -0.1
+        message_block_idx = torch.zeros(len(edge_distance), device=pos.device)
+        edge_distance_reorder = torch.tensor([], device=self.device)
+        edge_index_reorder = torch.tensor([], device=self.device)
+        edge_distance_vec_reorder = torch.tensor([], device=self.device)
+        cutoff_index = torch.tensor([0], device=self.device)
+        for i in range(self.num_resolutions):
+            mask = torch.logical_and(
+                edge_rank.gt(last_cutoff), edge_rank.le(self.cutoff_list[i])
+            )
+            last_cutoff = self.cutoff_list[i]
+            message_block_idx.masked_fill_(mask, i)
+            edge_distance_reorder = torch.cat(
+                [
+                    edge_distance_reorder,
+                    torch.masked_select(edge_distance, mask),
+                ],
+                dim=0,
+            )
+            edge_index_reorder = torch.cat(
+                [
+                    edge_index_reorder,
+                    torch.masked_select(
+                        edge_index, mask.view(1, -1).repeat(2, 1)
+                    ).view(2, -1),
+                ],
+                dim=1,
+            )
+            edge_distance_vec_mask = torch.masked_select(
+                edge_distance_vec, mask.view(-1, 1).repeat(1, 3)
+            ).view(-1, 3)
+            edge_distance_vec_reorder = torch.cat(
+                [edge_distance_vec_reorder, edge_distance_vec_mask], dim=0
+            )
+            cutoff_index = torch.cat(
+                [
+                    cutoff_index,
+                    torch.tensor(
+                        [len(edge_distance_reorder)], device=self.device
+                    ),
+                ],
+                dim=0,
+            )
+
+        edge_index = edge_index_reorder.long()
+        edge_distance = edge_distance_reorder
+        edge_distance_vec = edge_distance_vec_reorder
+
+        # Compute 3x3 rotation matrix per edge
+        edge_rot_mat = self._init_edge_rot_mat(
+            data, edge_index, edge_distance_vec
+        )
+
+        # Initialize the WignerD matrices and other values for spherical harmonic calculations
+        for i in range(self.num_resolutions):
+            self.sphharm_list[i].InitWignerDMatrix(
+                edge_rot_mat[cutoff_index[i] : cutoff_index[i + 1]],
+            )
+
+        ###############################################################
+        # Initialize node embeddings
+        ###############################################################
+
+        # Init per node representations using an atomic number based embedding
+        x = torch.zeros(
+            num_atoms,
+            self.sphere_basis,
+            self.sphere_channels,
+            device=pos.device,
+        )
+        x[:, 0, :] = self.sphere_embedding(atomic_numbers)
+
+        ###############################################################
+        # Update spherical node embeddings
+        ###############################################################
+        
+        if self.atomic:
+            atom_representations = []
+            for i, interaction in enumerate(self.edge_blocks):
+                if i > 0:
+                    x = x + interaction(
+                        x, atomic_numbers, edge_distance, edge_index, cutoff_index
+                    )
+                    atom_representations.append(x)
+                else:
+                    x = interaction(
+                        x, atomic_numbers, edge_distance, edge_index, cutoff_index
+                    )
+                    atom_representations.append(x)
+            return atom_representations
+        
+        
+        if self.probe:
+            atom_indices = torch.nonzero(data.atomic_numbers).flatten()
+            probe_indices = (data.atomic_numbers == 0).nonzero().flatten()
+            
+            for i, interaction in enumerate(self.edge_blocks):
+                if i > 0:
+                    x = x + interaction(
+                        x, atomic_numbers, edge_distance, edge_index, cutoff_index
+                    )
+                    x[atom_indices] = data.atom_representations[i]
+                else:
+                    x = interaction(
+                        x, atomic_numbers, edge_distance, edge_index, cutoff_index
+                    )
+                    x[atom_indices] = data.atom_representations[i]
+                    
+            return x[probe_indices]
+
+    @property
+    def num_params(self):
+        return sum(p.numel() for p in self.parameters())

--- a/cdm/models/scn_charge.py
+++ b/cdm/models/scn_charge.py
@@ -76,64 +76,23 @@ class SCN_Charge(SCN):
 
     def __init__(
         self,
-        max_num_neighbors=10000,
-        cutoff=4.0,
-        max_num_elements=90,
-        num_interactions=8,
-        lmax=6,
-        mmax=1,
-        num_resolutions=2,
-        #sphere_channels=128,
-        #sphere_channels_reduce=128,
-        hidden_channels=256,
-        num_taps=-1,
-        use_grid=True,
-        num_bands=1,
-        num_sphere_samples=128,
-        num_basis_functions=128,
-        distance_function="gaussian",
-        basis_width_scalar=1.0,
-        distance_resolution=0.02,
-        show_timing_info=False,
-        direct_forces=True,
-        name='scn_charge',
-        atomic=False,
-        probe=False,
+        name = 'scn_charge',
+        **kwargs,
     ):
+        
+        self.atomic = kwargs['atomic']
+        self.probe = kwargs['probe']
+        kwargs.pop('atomic')
+        kwargs.pop('probe')
+                 
         super().__init__(
             num_atoms = 1,
             bond_feat_dim = 1,
             num_targets = 1,
-            use_pbc = True,
-            regress_forces = False,
             otf_graph = False,
-            max_num_neighbors = max_num_neighbors,
-            cutoff = cutoff,
-            max_num_elements = max_num_elements,
-            num_interactions = num_interactions,
-            lmax = lmax,
-            mmax = mmax,
-            num_resolutions = num_resolutions,
-            sphere_channels = hidden_channels,  ##
-            sphere_channels_reduce = hidden_channels, ##
-            hidden_channels = hidden_channels, ##
-            num_taps = num_taps,
-            use_grid = use_grid,
-            num_bands = num_bands,
-            num_sphere_samples = num_sphere_samples,
-            num_basis_functions = num_basis_functions,
-            distance_function = distance_function,
-            basis_width_scalar = basis_width_scalar,
-            distance_resolution = distance_resolution,
-            show_timing_info = show_timing_info,
-            direct_forces = direct_forces,
+            **kwargs,
         )
-        
-        self.atomic = atomic
-        self.probe = probe
-        self.num_interactions = num_interactions
 
-        
 
     @conditional_grad(torch.enable_grad())
     def forward(self, data):

--- a/cdm/models/scn_charge.py
+++ b/cdm/models/scn_charge.py
@@ -176,8 +176,6 @@ class SCN_Charge(SCN):
             _,  # cell offset distances
             neighbors,
         ) = self.generate_graph(data)
-        
-        pdb.set_trace()
 
         ###############################################################
         # Initialize data structures

--- a/cdm/utils/probe_graph.py
+++ b/cdm/utils/probe_graph.py
@@ -17,7 +17,7 @@ class ProbeGraphAdder():
     a 3-dimensional tensor of charge density values
     '''
     def __init__(self, 
-                 num_probes=1000, 
+                 num_probes=10000, 
                  cutoff=5, 
                  include_atomic_edges=False, 
                  mode = 'random', 

--- a/cdm/utils/probe_graph.py
+++ b/cdm/utils/probe_graph.py
@@ -56,11 +56,18 @@ class ProbeGraphAdder():
         # Handle batching
         if type(data_object.natoms) is not int:
             if len(data_object.natoms) > 1:
+                raise Exception(
+                    'Batch size >1 is not supported. \
+                    It is recommended to instead increase the number of probes per structure'
+                )
+                
+                '''
                 data_list = data_object.to_data_list()
                 batches = [data_list_collater([data]) for data in data_list]
                 probe_data = [self(batch).probe_data for batch in batches]
                 probe_data = data_list_collater(probe_data)
                 data_object.probe_data = probe_data
+                '''
                 return data_object
         
         # Use default options if none have been passed in


### PR DESCRIPTION
Summary of additions:

- Implementation of SCN
- Allow loading of a pre-trained model for atom messaging
- Allow models to have different number of interaction blocks (i.e. do not do probe messaging until final interaction block(s))
- Pass keyword arguments directly to the OCP implementations of models